### PR TITLE
Fix for recent versions of Home Assistant

### DIFF
--- a/custom_components/ventoptimization/__init__.py
+++ b/custom_components/ventoptimization/__init__.py
@@ -12,7 +12,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     This function is called by Home Assistant when the integration is set up with the UI.
     """
     # Forward entry setup for the sensor platform
-    await entry.async_create_task(await hass.config_entries.async_forward_entry_setups(entry, SENSOR_DOMAIN))
+    await hass.config_entries.async_forward_entry_setups(entry, [SENSOR_DOMAIN])
 
     # Add an update listener for this entry
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))

--- a/custom_components/ventoptimization/manifest.json
+++ b/custom_components/ventoptimization/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/HrGaertner/vent-optimization/issues/",
     "requirements": [],
-    "version": "0.5"
+    "version": "0.8"
   }

--- a/custom_components/ventoptimization/manifest.json
+++ b/custom_components/ventoptimization/manifest.json
@@ -4,9 +4,9 @@
     "codeowners": ["@HrGaertner"],
     "config_flow": true,
     "dependencies": [],
-    "documentation": "https://github.com/HrGaertner/vent-optimization",
+    "documentation": "https://github.com/HrGaertner/HA-vent-optimization",
     "iot_class": "local_polling",
-    "issue_tracker": "https://github.com/HrGaertner/vent-optimization/issues/",
+    "issue_tracker": "https://github.com/HrGaertner/HA-vent-optimization/issues/",
     "requirements": [],
     "version": "0.8"
   }

--- a/custom_components/ventoptimization/sensor.py
+++ b/custom_components/ventoptimization/sensor.py
@@ -322,7 +322,7 @@ class VentTime(SensorEntity):
         """Calculate latest state."""
         _LOGGER.debug("Update state for %s", self.entity_id)
         # check all sensors
-        if None in (self._indoor_temp, self._indoor_hum, self._outdoor_temp):
+        if None in (self._indoor_temp, self._indoor_hum, self._outdoor_temp, self._outdoor_hum):
             self._available = False
             self._outdoor_absolute_humidity = None
             self._indoor_absolute_humidity = None

--- a/custom_components/ventoptimization/sensor.py
+++ b/custom_components/ventoptimization/sensor.py
@@ -226,11 +226,11 @@ class VentTime(SensorEntity):
 
         if entity == self._indoor_temp_sensor:
             self._indoor_temp = VentTime._update_temp_sensor(new_state)
-        elif entity == self._outdoor_temp_sensor:
+        if entity == self._outdoor_temp_sensor:
             self._outdoor_temp = VentTime._update_temp_sensor(new_state)
-        elif entity == self._indoor_humidity_sensor:
+        if entity == self._indoor_humidity_sensor:
             self._indoor_hum = VentTime._update_hum_sensor(new_state)
-        elif entity == self._outdoor_humidity_sensor:
+        if entity == self._outdoor_humidity_sensor:
             self._outdoor_hum = VentTime._update_hum_sensor(new_state)
 
         return True
@@ -242,7 +242,7 @@ class VentTime(SensorEntity):
 
         # Return an error if the sensor change its state to Unknown.
         if state.state == STATE_UNKNOWN:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Unable to parse temperature sensor %s with state: %s",
                 state.entity_id,
                 state.state,
@@ -252,7 +252,7 @@ class VentTime(SensorEntity):
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
 
         if (temp := util.convert(state.state, float)) is None:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Unable to parse temperature sensor %s with state: %s",
                 state.entity_id,
                 state.state,
@@ -283,7 +283,7 @@ class VentTime(SensorEntity):
 
         # Return an error if the sensor change its state to Unknown.
         if state.state == STATE_UNKNOWN:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Unable to parse humidity sensor %s, state: %s",
                 state.entity_id,
                 state.state,
@@ -291,7 +291,7 @@ class VentTime(SensorEntity):
             return None
 
         if (hum := util.convert(state.state, float)) is None:
-            _LOGGER.error(
+            _LOGGER.debug(
                 "Unable to parse humidity sensor %s, state: %s",
                 state.entity_id,
                 state.state,


### PR DESCRIPTION
This integration is broken since April 2025 because of the deprecated call to `async_add_job`. Both version 0.7.0 and the main branch fail to initialize in recent versions of Home Assistant.

What this PR does:
- Remove deprecated `async_add_job`
- Change the GitHub link to point to this repository which is the one used by HACS
- Bump the version number to 0.8
- Don't fail if the same sensor is used for indoor and outdoor (for testing)
- Don't spam the log with error messages if a sensor is unavailable
- Add outdoor humidity sensor to the None check to avoid a crash

fixes https://github.com/HrGaertner/HA-vent-optimization/issues/35