### PR TITLE
More changes

### DIFF
--- a/custom_components/ventoptimization/config_flow.py
+++ b/custom_components/ventoptimization/config_flow.py
@@ -3,7 +3,7 @@ from typing import Any
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.sensor import SensorDeviceClass
-from homeassistant.const import CONF_NAME, PERCENTAGE, UnitOfVolume
+from homeassistant.const import CONF_NAME, PERCENTAGE, UnitOfArea, UnitOfVolume
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
 
@@ -63,7 +63,7 @@ class VentOptimizationFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_INDOOR_HUMIDITY, default=self._indoor_humidity): humidity_entity_selector,
                 vol.Required(CONF_OUTDOOR_HUMIDITY, default=self._outdoor_humidity): humidity_entity_selector,
                 vol.Optional(CONF_WINDOW_SIZE, default=self._window_size): selector.NumberSelector(
-                    selector.NumberSelectorConfig(min=0, max=10, step=0.1, unit_of_measurement=UnitOfVolume.CUBIC_METERS)
+                    selector.NumberSelectorConfig(min=0, max=10, step=0.1, unit_of_measurement=UnitOfArea.SQUARE_METERS)
                 ),
                 vol.Optional(CONF_ROOM_VOLUME, default=self._room_volume): selector.NumberSelector(
                     selector.NumberSelectorConfig(min=0, max=100, step=0.1, unit_of_measurement=UnitOfVolume.CUBIC_METERS)

--- a/custom_components/ventoptimization/manifest.json
+++ b/custom_components/ventoptimization/manifest.json
@@ -5,7 +5,7 @@
     "config_flow": true,
     "dependencies": [],
     "documentation": "https://github.com/HrGaertner/HA-vent-optimization",
-    "iot_class": "local_polling",
+    "iot_class": "local_push",
     "issue_tracker": "https://github.com/HrGaertner/HA-vent-optimization/issues/",
     "requirements": [],
     "version": "0.8"

--- a/custom_components/ventoptimization/sensor.py
+++ b/custom_components/ventoptimization/sensor.py
@@ -342,9 +342,9 @@ class VentTime(SensorEntity):
     def _calc_e_s(self, temp):
         """Calculate the maximum possible absolute humidity for the indoor temperature"""
         # According to https://journals.ametsoc.org/view/journals/bams/86/2/bams-86-2-225.xml?tab_body=pdf Equation 6 p.226
-        C_1 = 610.94 #Kp
-        A_1 =  17.625
-        B_1 =243.04 #°C
+        C_1 = 610.94 # Kp
+        A_1 = 17.625
+        B_1 = 243.04 # °C
         return C_1*math.exp((A_1*temp)/(B_1+temp))
 
     def _calc_indoor_absolute_humidity(self):
@@ -371,10 +371,10 @@ class VentTime(SensorEntity):
             # One could use a binary search here, but it is unecessary
             for i in range(301):
                 if (self._humidity_model(i)/self._calc_e_s(self._temperature_model(i)))*100 <= self._max_hum_allowed:
-                    self._state= f"{int(i):d}"
+                    self._state = i
                     break
             else:
-                self._state = 999999999
+                self._state = None
                 _LOGGER.debug("Venting would take longer than 5h")
 
 
@@ -408,6 +408,6 @@ class VentTime(SensorEntity):
     def extra_state_attributes(self):
         """Return the state attributes."""
         return {
-            ATTR_INDOOR_ABSOLUTE_HUMIDITY: round(self._indoor_absolute_humidity, 2) ,
+            ATTR_INDOOR_ABSOLUTE_HUMIDITY: round(self._indoor_absolute_humidity, 2),
             ATTR_OUTDOOR_ABSOLUTE_HUMIDITY: round(self._outdoor_absolute_humidity, 2)
         }

--- a/custom_components/ventoptimization/sensor.py
+++ b/custom_components/ventoptimization/sensor.py
@@ -374,7 +374,7 @@ class VentTime(SensorEntity):
                     self._state = i
                     break
             else:
-                self._state = None
+                self._state = 300
                 _LOGGER.debug("Venting would take longer than 5h")
 
 

--- a/custom_components/ventoptimization/translations/de.json
+++ b/custom_components/ventoptimization/translations/de.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Vent Optimization",
+        "description": "Eine Integration für Home Assistant, die vorhersagt, wie lange du lüften musst, um Schimmel zu verhindern.",
+        "data": {
+          "room_volume": "Zimmervolumen",
+          "indoor_humidity_sensor": "Innenluftluftfeuchtigkeits-Sensor",
+          "indoor_temp_sensor": "Innentemperatur-Sensor",
+          "outdoor_temp_sensor": "Außentemperatur-Sensor",
+          "outdoor_humidity_sensor": "Außenluftfeuchtigkeits-Sensor",
+          "maximum_wished_humidity": "Maximale gewünschte Luftfeuchtigkeit",
+          "total_open_window_surface": "Gesamtfläche der geöffneten Fenster"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "Ein Eintrag mit diesem Namen ist bereits konfiguriert",
+      "reconfigure_successful": "Erfolgreich neu konfiguriert"
+    }
+  }
+}

--- a/custom_components/ventoptimization/translations/en.json
+++ b/custom_components/ventoptimization/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Vent Optimization",
-        "description": "An integration for Home-Assistant that predicts how long you have to open your windows in order to prevent mold and other nasty things.",
+        "description": "An integration for Home Assistant that predicts how long you have to open your windows in order to prevent mold and other nasty things.",
         "data": {
           "room_volume": "Room Volume",
           "indoor_humidity_sensor": "Indoor Humidity Sensor",


### PR DESCRIPTION
What this PR does:
- Use square meters instead of cubic meters for window area
- Change `iot_class` to `local_push` (because the integration doesn't use polling)
- Set the sensor to ~unavailable~ 300 minutes instead of 999999999 minutes if venting takes too long. With 300 minutes the history graph still looks nice, and `unavailable` has the problem that the absolute humidity is no longer visible.
- Add German translation