### PR TITLE
Prepare for 0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,18 @@ And install the configuration
 
 ## Configuration
 You can configure and setup this integration via a Config Flow. Thanks a lot to [Alexwijn](https://github.com/Alexwijn)
+
 ![image](https://github.com/HrGaertner/HA-vent-optimization/assets/53614377/d1e04abb-b06d-4407-89e2-3754c54de6bf)
-```
+
+## Sensor Values
+- `0 minutes` means venting doesn't make sense right now because the outside is to humid
+- `1-299 minutes` means you should vent for that amount of time
+- `300 minutes` means it would take 300 minutes or longer to vent
+- `unavailable` means one or more of the temperature and humidity sensors are unavailable
 
 ## The optimization
-If you want to customize the opimization to adapt to your local situation gather trainingsdata and use either this [jupyter notebook](https://github.com/HrGaertner/vent-optimization/blob/main/code/model%7Ctraining/model-training.ipynb) or this [webapp](https://hrgaertner.github.io/vent-optimization/) (under "Training" (i am sorry it is currently German only))
+If you want to customize the opimization to adapt to your local situation gather training data and use either this [jupyter notebook](https://github.com/HrGaertner/vent-optimization/blob/main/code/model%7Ctraining/model-training.ipynb) or this [webapp](https://hrgaertner.github.io/vent-optimization/) (under "Training" (i am sorry it is currently German only))
 
 To learn about the model and the optimization itself have look at the whole repository dedicated to the development of the model and the webapp
-
 
 **This integration used the [Mold Indicator Integration](https://www.home-assistant.io/integrations/mold_indicator/) as a minimal template to start from.**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HA-vent-optimization
+# Vent Optimization
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/HrGaertner/HA-vent-optimization/actions.yaml?label=HA%20compatible&style=for-the-badge)
 
@@ -11,7 +11,7 @@ Use this link:
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=HrGaertner&repository=HA-vent-optimization&category=integration)
 
-And install the configuration
+And install the integration
 
 ## Configuration
 You can configure and setup this integration via a Config Flow. Thanks a lot to [Alexwijn](https://github.com/Alexwijn)

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,6 @@
 {
-    "name": "ventoptimization",
-    "render_readme": true
+    "name": "Vent Optimization",
+    "render_readme": true,
+    "zip_release": true,
+    "filename": "ventoptimization.zip"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-homeassistant==2023.12.3
+homeassistant==2025.9.3


### PR DESCRIPTION
Preparations for the `0.8` release of this integration

Release notes:
```
- Fix compatibility with Home Assistant 2025.4 and newer
- Add reconfigure button to allow changing the configuration without having to delete and recreate the integration
- Use different sensor values when venting doesn't make sense or would take longer than 300 minutes:
  - `0 minutes` means venting doesn't make sense right now because the outside is to humid
  - `1-299 minutes` means you should vent for that amount of time
  - `300 minutes` means it would take 300 minutes or longer to vent
  - `unavailable` means one or more of the temperature and humidity sensors are unavailable
- Don't log errors if sensors are unavailable
- German translation
- Small bug fixes
```
Zip file for the release: https://github.com/Mat931/ha-vent-optimization/releases/download/0.8-beta1/ventoptimization.zip